### PR TITLE
Stop using GUIDs for AsmDefs and fix readme

### DIFF
--- a/Packages/com.clpsplug.uniswitcher/README.md
+++ b/Packages/com.clpsplug.uniswitcher/README.md
@@ -17,7 +17,7 @@ Add these lines to your `manifest.json`:
 ```json
 {
   "dependencies": {
-    "com.clpsplug.uniswitcher": "https://github.com/clpsplug/uniswitcher.git",
+    "com.clpsplug.uniswitcher": "https://github.com/clpsplug/uniswitcher.git?path=Packages/com.clpsplug.uniswitcher",
     "com.coffee.git-dependency-resolver": "https://github.com/mob-sakai/GitDependencyResolverForUnity.git"
   }
 }

--- a/Packages/com.clpsplug.uniswitcher/Runtime/UniSwitcher.asmdef
+++ b/Packages/com.clpsplug.uniswitcher/Runtime/UniSwitcher.asmdef
@@ -1,8 +1,9 @@
 {
     "name": "UniSwitcher",
+    "rootNamespace": "UniSwitcher",
     "references": [
-        "GUID:0d8beb7f090555447a6cf5ce9e54dbb4",
-        "GUID:f51ebe6a0ceec4240a699833d6309b23"
+        "Zenject",
+        "UniTask"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## What problem does this issue solve? 

* Assembly Definition broke because it referenced the dependencies with GUIDs.
* Readme.md did not point to the correct package location.

## What does this PR add/fix?

Stopped using GUIDs for our assembly definitions and fixed the readme file.