### PR TITLE
Add third party notices

### DIFF
--- a/Packages/com.clpsplug.uniswitcher/THIRD PARTY NOTICES.md
+++ b/Packages/com.clpsplug.uniswitcher/THIRD PARTY NOTICES.md
@@ -1,0 +1,9 @@
+This package contains third-party software components governed by the license(s) indicated below:
+
+Component Name: Zenject  
+License Type: MIT  
+[MIT License](https://github.com/modesttree/Zenject/blob/master/License.md)
+
+Component Name: UniTask  
+License Type: MIT  
+[MIT License](https://github.com/Cysharp/UniTask/blob/master/LICENSE)

--- a/Packages/com.clpsplug.uniswitcher/THIRD PARTY NOTICES.md.meta
+++ b/Packages/com.clpsplug.uniswitcher/THIRD PARTY NOTICES.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f633666bb2944613b443c787f335115
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What problem does this issue solve? 

According to the [Unity documentation](https://docs.unity3d.com/Manual/CustomPackages.html), it is possible to add third-party notices to the package. As it is strongly recommended to put such a file, this project should follow suit.

## What does this PR add/fix?

[+] THIRD PARTY NOTICES.md file.
