### PR TITLE
Fix naming mistake so that we use names used by UGS

### DIFF
--- a/Assets/Scripts/Scene.cs
+++ b/Assets/Scripts/Scene.cs
@@ -15,7 +15,7 @@ public class Scene : BaseScene
     //       and set up Analytics for this project.
     //       After that, in the Event Manager, add a custom event type with this name that has a property with the name here.
     public override string ScreenVisitEventName => "screenVisit";
-    public override string ScreenVisitEventPropertyName => "screenName";
+    public override string ScreenVisitEventParameterName => "screenName";
     public bool DoNotReport()
     {
         return false;

--- a/Packages/com.clpsplug.uniswitcher/Runtime/Domain/BaseScene.cs
+++ b/Packages/com.clpsplug.uniswitcher/Runtime/Domain/BaseScene.cs
@@ -19,21 +19,27 @@ namespace UniSwitcher.Domain
         /// <inheritdoc cref="IScene.SuppressEvent"/>
         public virtual bool SuppressEvent => false;
 #endif
-        
+
 #if UGS_ANALYTICS
         /// <inheritdoc cref="IScene.ScreenVisitEventName"/>
         public virtual string ScreenVisitEventName => null;
-        /// <inheritdoc cref="IScene.ScreenVisitEventPropertyName"/>
+
+        /// <inheritdoc cref="IScene.ScreenVisitEventParameterName"/>
+#pragma warning disable CS0618
+        public virtual string ScreenVisitEventParameterName => ScreenVisitEventPropertyName;
+#pragma warning restore CS0618
+
+        [Obsolete("Please use ScreenVisitEventParameterName instead. This method was a typo.")]
         public virtual string ScreenVisitEventPropertyName => null;
 #endif
-        
+
         protected BaseScene(string rawValue)
         {
             _rawValue = rawValue;
         }
-        
-        public static bool operator ==(BaseScene a, BaseScene b) 
-        { 
+
+        public static bool operator ==(BaseScene a, BaseScene b)
+        {
             // null == null
             if (ReferenceEquals(a, null) && ReferenceEquals(b, null)) return true;
             // If either one is null but NOT both are non-null

--- a/Packages/com.clpsplug.uniswitcher/Runtime/Domain/IScene.cs
+++ b/Packages/com.clpsplug.uniswitcher/Runtime/Domain/IScene.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace UniSwitcher.Domain
 {
     /// <summary>
@@ -13,7 +15,7 @@ namespace UniSwitcher.Domain
 #if UNITY_ANALYTICS || UGS_ANALYTICS
         /// <summary>
         /// If true, suppresses warning raised whenever you don't implement <see cref="IReportable"/>
-        /// and/or (in case of Unity Gaming Service Analytics) override <see cref="ScreenVisitEventName"/> and <see cref="ScreenVisitEventPropertyName"/>.
+        /// and/or (in case of Unity Gaming Service Analytics) override <see cref="ScreenVisitEventName"/> and <see cref="ScreenVisitEventParameterName"/>.
         /// </summary>
         bool SuppressEvent { get; }
 #endif
@@ -31,6 +33,9 @@ namespace UniSwitcher.Domain
         /// If this or <see cref="ScreenVisitEventName"/> is null or the Scene definition doesn't implement <see cref="IReportable"/>,
         /// UniSwitcher will not send the event.
         /// </summary>
+        string ScreenVisitEventParameterName { get; }
+        
+        [Obsolete("Please use ScreenVisitEventParameterName instead. This method was a typo.")]
         string ScreenVisitEventPropertyName { get; }
 #endif
     }

--- a/Packages/com.clpsplug.uniswitcher/Runtime/Infra/SceneLoader.cs
+++ b/Packages/com.clpsplug.uniswitcher/Runtime/Infra/SceneLoader.cs
@@ -159,7 +159,7 @@ namespace UniSwitcher.Infra
             }
 #endif
 #if UGS_ANALYTICS
-            if (!string.IsNullOrEmpty(target.ScreenVisitEventName) && !string.IsNullOrEmpty(target.ScreenVisitEventPropertyName))
+            if (!string.IsNullOrEmpty(target.ScreenVisitEventName) && !string.IsNullOrEmpty(target.ScreenVisitEventParameterName))
             {
                 switch (target)
                 {
@@ -173,7 +173,7 @@ namespace UniSwitcher.Infra
                     default:
                         Debug.LogWarning(
                             $"Heads up! Your Scene definition ({target.GetType().Name}) does not implement IReportable; the event was not sent to prevent unexpectedly using up your event quota.\n" 
-                            + $"Since you have overridden both {nameof(target.ScreenVisitEventName)} and {nameof(target.ScreenVisitEventPropertyName)}, you probably intend to use UGS Analytics.\n"
+                            + $"Since you have overridden both {nameof(target.ScreenVisitEventName)} and {nameof(target.ScreenVisitEventParameterName)}, you probably intend to use UGS Analytics.\n"
                             + "Please implement IReportable to start sending the events.\n"
                             + "For more information, refer to https://github.com/Clpsplug/UniSwitcher/wiki/UGS-Analytics for details."
                         );
@@ -183,7 +183,7 @@ namespace UniSwitcher.Infra
             else
             {
                 Debug.LogWarning(
-                    $"Heads up! You have UGS Analytics package in this project, but your screen definition does not implement either (or both) of {nameof(target.ScreenVisitEventName)} or {nameof(target.ScreenVisitEventPropertyName)}.\n"
+                    $"Heads up! You have UGS Analytics package in this project, but your screen definition does not implement either (or both) of {nameof(target.ScreenVisitEventName)} or {nameof(target.ScreenVisitEventParameterName)}.\n"
                     + $"If you want UniSwitcher to report 'Screen Visit' events, please override both and implement IReportable into your Scene definition ({target.GetType().Name}.)\n"
                     + $"If you don't, but you still want to include UGS Analytics, please override {nameof(target.SuppressEvent)} and set it to true.\n"
                     + $"If you didn't mean to use Analytics in your project, consider removing com.unity.services.analytics package from this project."
@@ -198,7 +198,7 @@ namespace UniSwitcher.Infra
             AnalyticsService.Instance.CustomData(
                 target.ScreenVisitEventName, 
     new Dictionary<string,object> {
-                    {target.ScreenVisitEventPropertyName, target.RawValue}
+                    {target.ScreenVisitEventParameterName, target.RawValue},
                 }
             );
         }


### PR DESCRIPTION
## What problem does this issue solve? 

There was a discrepancy between the word used by UniSwitcher and UGS. UGS events have associated **parameters,** not *properties.*

## What does this PR add/fix?

Deprecate `IScene.ScreenVisitEventPropertyName` and migrate to `IScene.ScreenVisitEventParameterName` instead.
